### PR TITLE
Change Chocolatey install command for cygwin

### DIFF
--- a/README.cygwin.md
+++ b/README.cygwin.md
@@ -7,7 +7,7 @@ Open cmd as admin, and install chocolatey, and then install Cygwin x86.
 
 ```
 @powershell -NoProfile -ExecutionPolicy Bypass -Command "iex ((new-object net.webclient).DownloadString('https://chocolatey.org/install.ps1'))" && SET PATH=%PATH%;%ALLUSERSPROFILE%\chocolatey\bin
-choco install cygwin -x86
+choco install cygwin -x86 -version 2.3.0
 ```
 
 You now need to open cygwin, in its default location under the START>All Programs>Cygwin>Cygwin Terminal. Once in, install apt-cyg and use that to install most software.


### PR DESCRIPTION
Chocolatey cygwin install version 2.3.1 doesn't install cygwin in the same way as version 2.3.0 and before. This causes symlinks to not work (awk => gawk) and other weird issues. Forcing the cygwin version back to 2.3.0 fixes these issues.
