### PR TITLE
Include directions for starting cygserver

### DIFF
--- a/README.cygwin.md
+++ b/README.cygwin.md
@@ -67,3 +67,11 @@ cmake .
 make
 make install
 ```
+
+To run GT.M you need to install and start the cygserver
+
+In an administrator cygwin-terminal (right click cygwin-terminal and click run as administrator)
+```
+/usr/bin/cygserver-config
+net start cygserver
+```


### PR DESCRIPTION
cygserver is required to be started since GT.M uses shared memory and semaphores and cygwin implements those using the cygserver.
