### PR TITLE
CMake build improvements and GT.M can use MOSX's ICU library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -760,23 +760,28 @@ install(FILES ${scripts}
   PERMISSIONS ${install_permissions_script}
   )
 
+set(GTM_SET_ICU_VERSION 1 CACHE BOOL "By default search for the ICU version number")
+if(GTM_SET_ICU_VERSION)
 find_program(ICUCONFIG NAMES icu-config)
-if(ICUCONFIG)
-  execute_process(
-    COMMAND ${ICUCONFIG} --version
-    OUTPUT_VARIABLE icu_version
-    RESULT_VARIABLE icu_failed
-    OUTPUT_STRIP_TRAILING_WHITESPACE
-    )
-  if(icu_failed)
-    message(FATAL_ERROR "Command\n ${ICUCONFIG} --version\nfailed (${icu_failed}).")
-  elseif("x${icu_version}" MATCHES "^x([0-9]+\\.[0-9]+)")
-    set(gtm_icu_version "${CMAKE_MATCH_1}")
+  if(ICUCONFIG)
+    execute_process(
+      COMMAND ${ICUCONFIG} --version
+      OUTPUT_VARIABLE icu_version
+      RESULT_VARIABLE icu_failed
+      OUTPUT_STRIP_TRAILING_WHITESPACE
+      )
+    if(icu_failed)
+      message(FATAL_ERROR "Command\n ${ICUCONFIG} --version\nfailed (${icu_failed}).")
+    elseif("x${icu_version}" MATCHES "^x([0-9]+\\.[0-9]+)")
+      set(gtm_icu_version "${CMAKE_MATCH_1}")
+    else()
+      message(FATAL_ERROR "Command\n ${ICUCONFIG} --version\nproduced unrecognized output:\n ${icu_version}")
+    endif()
   else()
-    message(FATAL_ERROR "Command\n ${ICUCONFIG} --version\nproduced unrecognized output:\n ${icu_version}")
+    message(FATAL_ERROR "Unable to find 'icu-config'.  Set ICUCONFIG in CMake cache.")
   endif()
 else()
-  message(FATAL_ERROR "Unable to find 'icu-config'.  Set ICUCONFIG in CMake cache.")
+  message("Not setting gtm_icu_version")
 endif()
 
 find_program(LOCALECFG NAMES locale)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,6 @@
 # CMake 2.8.12 Adds MacOSX RPATH
 cmake_minimum_required(VERSION 2.8.12)
 project(GTM C ASM)
-set(CMAKE_MACOSX_RPATH 1)
 
 # Max optimization level is -O2
 get_property(languages GLOBAL PROPERTY ENABLED_LANGUAGES)

--- a/sr_darwin/platform.cmake
+++ b/sr_darwin/platform.cmake
@@ -44,13 +44,31 @@ add_definitions(
   -D_DARWIN_C_SOURCE
   )
 
+# Locate external packages
+find_package(Curses REQUIRED) # FindCurses.cmake
+include_directories(${CURSES_INCLUDE_PATH})
+
+find_package(Zlib REQUIRED)   # FindZLIB.cmake
+include_directories(${ZLIB_INCLUDE_DIRS})
+
+find_library(LIBELF_LIBRARY_PATH NAMES elf)
+if(LIBELF_LIBRARY_PATH)
+  message("-- Found libelf: ${LIBELF_LIBRARY_PATH}")
+endif()
+get_filename_component(_libelfLibDir "${LIBELF_LIBRARY_PATH}" PATH)
+get_filename_component(_libelfParentDir "${_libelfLibDir}" PATH)
+find_path(LIBELF_INCLUDE_PATH NAMES libelf.h libelf/libelf.h HINTS "${_libelfParentDir}/include" )
+include_directories(${LIBELF_INCLUDE_PATH})
+
+
+# Set some MOSX specific stuff 
+set(CMAKE_MACOSX_RPATH 1)
+# Found these on the web: CMAKE_OSX_ARCHITECTURES, CMAKE_OSX_DEPLOYMENT_TARGET, CMAKE_OSX_SYSROOT
+
 # Linker
 set(gtm_link  "-Wl,-U,gtm_filename_to_id -Wl,-U,gtm_zstatus -Wl,-v -Wl,-exported_symbols_list \"${GTM_BINARY_DIR}/gtmexe_symbols.export\"")
 set(libgtmshr_link "-Wl,-U,gtm_ci -Wl,-U,gtm_filename_to_id -Wl,-exported_symbols_list \"${GTM_BINARY_DIR}/gtmshr_symbols.export\"")
 set(libgtmshr_dep  "${GTM_BINARY_DIR}/gtmexe_symbols.export")
 
-set(libmumpslibs "-lncurses -lm -ldl -lc -lpthread -lelf")
+set(libmumpslibs "-lm -ldl -lc -lpthread ${LIBELF_LIBRARY_PATH} ${CURSES_NCURSES_LIBRARY}")
 
-
-include_directories (/opt/local/include /Volumes/Vault/ports/include)
-link_directories (/opt/local/lib/)

--- a/sr_darwin/platform.cmake
+++ b/sr_darwin/platform.cmake
@@ -60,6 +60,7 @@ get_filename_component(_libelfParentDir "${_libelfLibDir}" PATH)
 find_path(LIBELF_INCLUDE_PATH NAMES libelf.h libelf/libelf.h HINTS "${_libelfParentDir}/include" )
 include_directories(${LIBELF_INCLUDE_PATH})
 
+set(GTM_SET_ICU_VERSION 0 CACHE BOOL "Unless you want ICU from MacPorts/other avoid setting gtm_icu_version to get Apple's undocumented ICU library")
 
 # Set some MOSX specific stuff 
 set(CMAKE_MACOSX_RPATH 1)

--- a/sr_unix/gtm_icu.c
+++ b/sr_unix/gtm_icu.c
@@ -271,7 +271,11 @@ void gtm_icu_init(void)
 		assert(SIZEOF(icu_libname) > icu_libname_len);
 		libname = icu_libname;
 	} else
+#if defined(__APPLE__)
+		libname = APPLE_ICU_LIB_NAME; /* Use Apple's undocumented private ICU implementation with unrenamed symbols */
+#else
 		libname = ICU_LIBNAME;	/* go with default name */
+#endif
 #	ifdef _AIX
 	/* AIX has a unique packaging convention in that shared objects are conventionally
 	 * archived into a static (.a) library. To resolve the shared library name at runtime

--- a/sr_unix/mdefsa.h
+++ b/sr_unix/mdefsa.h
@@ -57,6 +57,7 @@
 #elif defined(__APPLE__)
 #	define GTMSHR_IMAGE_NAME	"libgtmshr.dylib"
 #	define	ICU_LIBNAME_EXT		"dylib"
+#	define APPLE_ICU_LIB_NAME	"libicucore.dylib"
 #else
 #	define GTMSHR_IMAGE_NAME	"libgtmshr.so"
 #	ifdef _AIX


### PR DESCRIPTION
Sam,
I moved the rpath directive into sr_darwin/platform.cmake. I also adjusted CMakeLists.txt to search for libraries in lieu of hard coding the link. Let me know how it works for you.

I knew that MOSX has ICU support, so I went looking for the library. It's private, but apparently others have linked to it from C. I dropped that in and it worked.

I wanted to give the pull request doohickey a try, so I'm doing it this way.

Amul
